### PR TITLE
Drop backwards-compatibility shim

### DIFF
--- a/records_mover/s3_url.py
+++ b/records_mover/s3_url.py
@@ -1,1 +1,0 @@
-from .url.s3.s3_url import S3Url  # noqa

--- a/tests/unit/test_s3_url.py
+++ b/tests/unit/test_s3_url.py
@@ -1,4 +1,4 @@
-from records_mover.s3_url import S3Url
+from records_mover.url.s3.s3_url import S3Url
 import unittest
 from mock import Mock, patch
 


### PR DESCRIPTION
records_mover/s3_url.py existed because there was a direct import from an internal use a while back and I wanted to refactor this into the then-new 'url' package.  I searched internal github and I'm no longer finding it, so I think we're good!  Even if we weren't, we could add a shim in the internal project pointing to the right location; if someone were importing this they'd be pointing to that project anyway!