### PR TITLE
Use the latest published db-facts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(name='records-mover',
           'sqlalchemy',
           # Not sure how/if interface will change in db-facts, so
           # let's be conservative about what we're specifying for now.
-          'db-facts>=2.15.3,<3',
+          'db-facts>=3,<4',
           'odictliteral',
           # we rely on exception types from smart_open,
           # which seem to change in feature releases

--- a/tests/integration/bin/db
+++ b/tests/integration/bin/db
@@ -46,7 +46,7 @@ else
     shift
   fi
 
-  eval "$(db-facts "${DB_NAME:?}")"
+  eval "$(db-facts sh "${DB_NAME:?}")"
 
   "${DIR:?}/arg-to-stdin" "${FILENAME:?}" template -n "${FILENAME:?}" -- "${@}" | \
     "${DIR:?}/with-db" "${DB_NAME:?}" "${DIR:?}/db-connect"

--- a/tests/integration/bin/with-db
+++ b/tests/integration/bin/with-db
@@ -14,7 +14,7 @@ then
   exit 1
 fi
 
-eval "$(db-facts "${DB_NAME:?}")"
+eval "$(db-facts sh "${DB_NAME:?}")"
 
 if [ n"${DB_PROTOCOL}" == n ]
 then


### PR DESCRIPTION
The breaking changes don't affect Python-based use, thankfully.   As seen in some of our vendored test utility scripts, there's going to be changes to other scripts that use this.