### PR TITLE
Add README.md to Docker builds so that setup.py can include it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV PATH $PATH:/opt/vertica/bin
 
 WORKDIR /usr/src/app
 
-COPY requirements.txt setup.py setuputils.py /usr/src/app/
+COPY README.md requirements.txt setup.py setuputils.py /usr/src/app/
 
 RUN mkdir /usr/src/app/records_mover
 


### PR DESCRIPTION
Example failure on docker build:

```
make docker                     ✔  records-mover-3.8.1 🐍  records-mover-3.8.1 🐍  16:53:57 
docker build --progress=plain -t records-mover .
Sending build context to Docker daemon  2.311MB
Step 1/13 : FROM python:3.6
 ---> 1daf62e8cab5
Step 2/13 : RUN apt-get update && apt-get install -y netcat jq postgresql-client curl
 ---> Using cache
 ---> 654b33a02cc4
Step 3/13 : RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
 ---> Using cache
 ---> 44e55b97c659
Step 4/13 : RUN ln -s /bin/zcat /bin/gzcat
 ---> Using cache
 ---> 1a38b2bdd317
Step 5/13 : RUN cd / &&     wget https://www.vertica.com/client_drivers/9.2.x/9.2.0-0/vertica-client-9.2.0-0.x86_64.tar.gz &&     tar -xzvf vertica-client-9.2.0-0.x86_64.tar.gz &&     rm -fr /vertica-client-9.2.0-0.x86_64.tar.gz /opt/vertica/Python/ /opt/vertica/java /opt/vertica/bin/vsql32
 ---> Using cache
 ---> b82c108604bc
Step 6/13 : ENV PATH $PATH:/opt/vertica/bin
 ---> Using cache
 ---> a16860e8fa94
Step 7/13 : WORKDIR /usr/src/app
 ---> Using cache
 ---> 42aa3ae60c9a
Step 8/13 : COPY requirements.txt setup.py setuputils.py /usr/src/app/
 ---> Using cache
 ---> f3d3e19775ab
Step 9/13 : RUN mkdir /usr/src/app/records_mover
 ---> Using cache
 ---> e7fae3c585e6
Step 10/13 : COPY records_mover/version.py /usr/src/app/records_mover
 ---> Using cache
 ---> 013ac8b8a862
Step 11/13 : RUN pip3 install --no-cache-dir -r requirements.txt -e '/usr/src/app[movercli]'
 ---> Running in e41c96e68695
Obtaining file:///usr/src/app
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/usr/src/app/setup.py'"'"'; __file__='"'"'/usr/src/app/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info
         cwd: /usr/src/app/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/src/app/setup.py", line 25, in <module>
        with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
    FileNotFoundError: [Errno 2] No such file or directory: '/usr/src/app/README.md'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
The command '/bin/sh -c pip3 install --no-cache-dir -r requirements.txt -e '/usr/src/app[movercli]'' returned a non-zero code: 1
make: *** [docker] Error 1
```