### PR TITLE
Fix potential issue in PostgreSQL CSV format handling

### DIFF
--- a/records_mover/db/postgres/copy_options/csv.py
+++ b/records_mover/db/postgres/copy_options/csv.py
@@ -95,6 +95,7 @@ def postgres_copy_options_csv(unhandled_hints: Set[str],
             cant_handle_hint(fail_if_cant_handle_hint, 'quoting', hints)
     else:
         _assert_never(mode)
+    quiet_remove(unhandled_hints, 'quoting')
 
     # As of the 9.2 release (documentation as of 2019-03-12), there's
     # no statement in the docs on what newline formats are accepted in

--- a/records_mover/db/postgres/unloader.py
+++ b/records_mover/db/postgres/unloader.py
@@ -104,7 +104,6 @@ class PostgresUnloader(Unloader):
     def can_unload_this_format(self, target_records_format: BaseRecordsFormat) -> bool:
         try:
             unload_plan = RecordsUnloadPlan(records_format=target_records_format)
-            unhandled_hints = set()
             records_format = unload_plan.records_format
             if not isinstance(records_format, DelimitedRecordsFormat):
                 return False

--- a/tests/unit/db/postgres/test_copy_options_csv_unload.py
+++ b/tests/unit/db/postgres/test_copy_options_csv_unload.py
@@ -7,12 +7,12 @@ from records_mover.db.postgres.copy_options.mode import CopyOptionsMode
 
 class TestCopyOptionsCsvUnload(unittest.TestCase):
     def test_postgres_copy_options_csv_minimal_quoting(self):
-        unhandled_hints = set()
         records_format = DelimitedRecordsFormat(variant='csv',
                                                 hints={
                                                     'quoting': 'minimal',
                                                     'compression': None,
                                                 })
+        unhandled_hints = set(records_format.hints)
         fail_if_cant_handle_hint = True
         mode = CopyOptionsMode.UNLOADING
 
@@ -30,12 +30,12 @@ class TestCopyOptionsCsvUnload(unittest.TestCase):
         })
 
     def test_postgres_copy_options_csv_all_quoting(self):
-        unhandled_hints = set()
         records_format = DelimitedRecordsFormat(variant='csv',
                                                 hints={
                                                     'quoting': 'all',
                                                     'compression': None,
                                                 })
+        unhandled_hints = set(records_format.hints)
         fail_if_cant_handle_hint = True
         mode = CopyOptionsMode.UNLOADING
 
@@ -54,12 +54,12 @@ class TestCopyOptionsCsvUnload(unittest.TestCase):
         })
 
     def test_postgres_copy_options_csv_no_quoting(self):
-        unhandled_hints = set()
         records_format = DelimitedRecordsFormat(variant='csv',
                                                 hints={
                                                     'quoting': None,
                                                     'compression': None,
                                                 })
+        unhandled_hints = set(records_format.hints)
         fail_if_cant_handle_hint = True
 
         with self.assertRaises(NotImplementedError):

--- a/tests/unit/db/postgres/test_postgres_copy_from_options.py
+++ b/tests/unit/db/postgres/test_postgres_copy_from_options.py
@@ -9,7 +9,7 @@ class TestPostgresCopyFromOptions(unittest.TestCase):
         records_format = DelimitedRecordsFormat(variant='bluelabs',
                                                 hints={'compression': None})
         records_format.hints['encoding'] = 'NEWNEWENCODING'
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         load_plan = RecordsLoadPlan(processing_instructions,
                                     records_format)
@@ -20,7 +20,7 @@ class TestPostgresCopyFromOptions(unittest.TestCase):
         records_format = DelimitedRecordsFormat(variant='bluelabs',
                                                 hints={'compression': None})
         records_format.hints['escape'] = None
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         load_plan = RecordsLoadPlan(processing_instructions,
                                     records_format)
@@ -31,7 +31,7 @@ class TestPostgresCopyFromOptions(unittest.TestCase):
         records_format = DelimitedRecordsFormat(variant='bluelabs',
                                                 hints={'compression': None})
         records_format.hints['doublequote'] = '"'
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         load_plan = RecordsLoadPlan(processing_instructions,
                                     records_format)
@@ -42,7 +42,7 @@ class TestPostgresCopyFromOptions(unittest.TestCase):
         records_format = DelimitedRecordsFormat(variant='vertica',
                                                 hints={'compression': None})
         records_format.hints['escape'] = '\\'
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         load_plan = RecordsLoadPlan(processing_instructions,
                                     records_format)
@@ -52,7 +52,7 @@ class TestPostgresCopyFromOptions(unittest.TestCase):
     def test_bluelabs_with_compression(self):
         records_format = DelimitedRecordsFormat(variant='bluelabs',
                                                 hints={'compression': 'GZIP'})
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         load_plan = RecordsLoadPlan(processing_instructions,
                                     records_format)
@@ -63,7 +63,7 @@ class TestPostgresCopyFromOptions(unittest.TestCase):
         records_format = DelimitedRecordsFormat(variant='csv',
                                                 hints={'compression': None,
                                                        'escape': '\\'})
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         load_plan = RecordsLoadPlan(processing_instructions,
                                     records_format)
@@ -74,7 +74,7 @@ class TestPostgresCopyFromOptions(unittest.TestCase):
         records_format = DelimitedRecordsFormat(variant='csv',
                                                 hints={'compression': None,
                                                        'doublequote': None})
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         load_plan = RecordsLoadPlan(processing_instructions,
                                     records_format)
@@ -85,7 +85,7 @@ class TestPostgresCopyFromOptions(unittest.TestCase):
         records_format = DelimitedRecordsFormat(variant='csv',
                                                 hints={'compression': None,
                                                        'quoting': 'all'})
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         load_plan = RecordsLoadPlan(processing_instructions,
                                     records_format)

--- a/tests/unit/db/postgres/test_postgres_copy_from_options_load_known.py
+++ b/tests/unit/db/postgres/test_postgres_copy_from_options_load_known.py
@@ -16,18 +16,19 @@ class TestPostgresCopyOptionsLoadKnown(unittest.TestCase):
                                 db=mock_db)
         known_load_formats = loader.known_supported_records_formats_for_load()
         for records_format in known_load_formats:
-            unhandled_hints = set()
+            unhandled_hints = set(records_format.hints)
             processing_instructions = ProcessingInstructions()
             load_plan = RecordsLoadPlan(processing_instructions,
                                         records_format)
             # ensure no exception thrown
             postgres_copy_from_options(unhandled_hints,
                                        load_plan)
+            self.assertFalse(unhandled_hints)
 
     def test_bluelabs_uncompressed(self):
         records_format = DelimitedRecordsFormat(variant='bluelabs',
                                                 hints={'compression': None})
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         load_plan = RecordsLoadPlan(processing_instructions,
                                     records_format)
@@ -44,7 +45,7 @@ class TestPostgresCopyOptionsLoadKnown(unittest.TestCase):
     def test_csv_uncompressed(self):
         records_format = DelimitedRecordsFormat(variant='csv',
                                                 hints={'compression': None})
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         load_plan = RecordsLoadPlan(processing_instructions,
                                     records_format)
@@ -62,7 +63,7 @@ class TestPostgresCopyOptionsLoadKnown(unittest.TestCase):
     def test_bigquery_uncompressed(self):
         records_format = DelimitedRecordsFormat(variant='bigquery',
                                                 hints={'compression': None})
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         load_plan = RecordsLoadPlan(processing_instructions,
                                     records_format)

--- a/tests/unit/db/postgres/test_postgres_copy_from_options_unload_known.py
+++ b/tests/unit/db/postgres/test_postgres_copy_from_options_unload_known.py
@@ -10,8 +10,9 @@ class TestPostgresCopyOptionsUnloadKnown(unittest.TestCase):
         loader = PostgresUnloader(db=mock_db)
         known_unload_formats = loader.known_supported_records_formats_for_unload()
         for records_format in known_unload_formats:
-            unhandled_hints = set()
+            unhandled_hints = set(records_format.hints)
             # ensure no exception thrown
             postgres_copy_to_options(unhandled_hints,
                                      records_format,
                                      fail_if_cant_handle_hint=True)
+            self.assertFalse(unhandled_hints)

--- a/tests/unit/db/postgres/test_postgres_copy_to_options.py
+++ b/tests/unit/db/postgres/test_postgres_copy_to_options.py
@@ -19,7 +19,7 @@ class TestPostgresCopyToOptions(unittest.TestCase):
         mock_postgres_copy_options = mock_postgres_copy_options_csv.return_value
         mock_determine_date_output_style.return_value = (mock_date_output_style,
                                                          mock_date_order_style)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         out = postgres_copy_to_options(unhandled_hints,
                                        records_format,
                                        fail_if_cant_handle_hint=True)
@@ -43,7 +43,7 @@ class TestPostgresCopyToOptions(unittest.TestCase):
         mock_postgres_copy_options = mock_postgres_copy_options_text.return_value
         mock_determine_date_output_style.return_value = (mock_date_output_style,
                                                          mock_date_order_style)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         out = postgres_copy_to_options(unhandled_hints,
                                        records_format,
                                        fail_if_cant_handle_hint=True)

--- a/tests/unit/db/vertica/test_records_import_options.py
+++ b/tests/unit/db/vertica/test_records_import_options.py
@@ -8,8 +8,8 @@ class TestVerticaImportOptions(unittest.TestCase):
     maxDiff = None
 
     def test_vertica_import_options_max_failure_rows_specified(self):
-        unhandled_hints = set()
         records_format = DelimitedRecordsFormat(variant='vertica')
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions(max_failure_rows=123)
         load_plan = RecordsLoadPlan(processing_instructions=processing_instructions,
                                     records_format=records_format)

--- a/tests/unit/records/pandas/test_read_csv_options.py
+++ b/tests/unit/records/pandas/test_read_csv_options.py
@@ -12,7 +12,7 @@ class TestReadCsvOptions(unittest.TestCase):
         records_schema = RecordsSchema.from_data({
             'schema': 'bltypes/v1'
         })
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         processing_instructions = ProcessingInstructions()
         expectations = {
             'compression': 'bz2'

--- a/tests/unit/records/test_pandas_read_csv_options.py
+++ b/tests/unit/records/test_pandas_read_csv_options.py
@@ -49,7 +49,7 @@ class TestPandasReadCsvOptions(unittest.TestCase):
         }
         processing_instructions = ProcessingInstructions()
         records_format = DelimitedRecordsFormat(hints=bluelabs_format_hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         actual = pandas_read_csv_options(records_format,
                                          self.records_schema,
                                          unhandled_hints,
@@ -82,7 +82,7 @@ class TestPandasReadCsvOptions(unittest.TestCase):
             'datetimeformat': 'DD-MM-YYYY HH24:MI',
         })
         records_format = DelimitedRecordsFormat(hints=hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         actual = pandas_read_csv_options(records_format,
                                          self.records_schema,
                                          unhandled_hints,
@@ -99,7 +99,7 @@ class TestPandasReadCsvOptions(unittest.TestCase):
             'datetimeformat': 'DD-MM-YYYY HH24:MI',
         })
         records_format = DelimitedRecordsFormat(hints=hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         with self.assertRaises(NotImplementedError):
             pandas_read_csv_options(records_format,
                                     self.records_schema,
@@ -124,7 +124,7 @@ class TestPandasReadCsvOptions(unittest.TestCase):
         }
         processing_instructions = ProcessingInstructions()
         records_format = DelimitedRecordsFormat(hints=csv_format_hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         actual = pandas_read_csv_options(records_format,
                                          self.records_schema,
                                          unhandled_hints,
@@ -151,7 +151,7 @@ class TestPandasReadCsvOptions(unittest.TestCase):
         }
         processing_instructions = ProcessingInstructions()
         records_format = DelimitedRecordsFormat(hints=vertica_format_hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         actual = pandas_read_csv_options(records_format,
                                          self.records_schema,
                                          unhandled_hints,

--- a/tests/unit/records/test_pandas_to_csv_options_bluelabs.py
+++ b/tests/unit/records/test_pandas_to_csv_options_bluelabs.py
@@ -21,7 +21,7 @@ class TestPandasToCsvOptionsBlueLabs(unittest.TestCase):
         }
         processing_instructions = ProcessingInstructions()
         records_format = DelimitedRecordsFormat(hints=bluelabs_format_hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         actual = pandas_to_csv_options(records_format, unhandled_hints, processing_instructions)
         self.assertEqual(expected, actual)
         self.assertFalse(unhandled_hints)

--- a/tests/unit/records/test_pandas_to_csv_options_christmas_tree.py
+++ b/tests/unit/records/test_pandas_to_csv_options_christmas_tree.py
@@ -24,7 +24,7 @@ class TestPandasToCsvOptionsChristmasTree(unittest.TestCase):
         processing_instructions =\
             ProcessingInstructions(fail_if_cant_handle_hint=False)
         records_format = DelimitedRecordsFormat(hints=christmas_tree_format_1_hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         with patch.object(driver_logger, 'warning') as mock_warning:
             actual = pandas_to_csv_options(records_format, unhandled_hints, processing_instructions)
             self.assertEqual(expected, actual)
@@ -50,7 +50,7 @@ class TestPandasToCsvOptionsChristmasTree(unittest.TestCase):
         processing_instructions =\
             ProcessingInstructions(fail_if_cant_handle_hint=False)
         records_format = DelimitedRecordsFormat(hints=christmas_tree_format_2_hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         with patch.object(driver_logger, 'warning') as mock_warning:
             actual = pandas_to_csv_options(records_format, unhandled_hints, processing_instructions)
             self.assertEqual(expected, actual)
@@ -75,7 +75,7 @@ class TestPandasToCsvOptionsChristmasTree(unittest.TestCase):
         processing_instructions =\
             ProcessingInstructions(fail_if_cant_handle_hint=False)
         records_format = DelimitedRecordsFormat(hints=christmas_tree_format_3_hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         with patch.object(driver_logger, 'warning') as mock_warning:
             actual = pandas_to_csv_options(records_format, unhandled_hints, processing_instructions)
             self.assertEqual(expected, actual)
@@ -100,7 +100,7 @@ class TestPandasToCsvOptionsChristmasTree(unittest.TestCase):
         processing_instructions =\
             ProcessingInstructions(fail_if_cant_handle_hint=False)
         records_format = DelimitedRecordsFormat(hints=christmas_tree_format_4_hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         with patch.object(driver_logger, 'warning') as mock_warning:
             actual = pandas_to_csv_options(records_format, unhandled_hints, processing_instructions)
             self.assertEqual(expected, actual)

--- a/tests/unit/records/test_pandas_to_csv_options_csv.py
+++ b/tests/unit/records/test_pandas_to_csv_options_csv.py
@@ -21,7 +21,7 @@ class TestPandasToCsvOptionsCsv(unittest.TestCase):
         processing_instructions =\
             ProcessingInstructions(fail_if_cant_handle_hint=True)
         records_format = DelimitedRecordsFormat(hints=csv_format_hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         actual = pandas_to_csv_options(records_format, unhandled_hints, processing_instructions)
         self.assertEqual(expected, actual)
         self.assertFalse(unhandled_hints)

--- a/tests/unit/records/test_pandas_to_csv_options_dateformats.py
+++ b/tests/unit/records/test_pandas_to_csv_options_dateformats.py
@@ -26,7 +26,7 @@ class TestPandasToCsvOptionsDateformats(unittest.TestCase):
                                        'datetimeformattz': 'YYYY-MM-DD HH24:MI:SS',
                                        'datetimeformat': 'YYYY-MM-DD HH24:MI:SS',
                                    })
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         actual = pandas_to_csv_options(records_format, unhandled_hints, processing_instructions)
         self.assertEqual(expected, actual)
         self.assertFalse(unhandled_hints)
@@ -52,7 +52,7 @@ class TestPandasToCsvOptionsDateformats(unittest.TestCase):
                                        'datetimeformattz': 'MM-DD-YYYY HH24:MI:SS',
                                        'datetimeformat': 'MM-DD-YYYY HH24:MI:SS',
                                    })
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         actual = pandas_to_csv_options(records_format, unhandled_hints, processing_instructions)
         self.assertEqual(expected, actual)
         self.assertFalse(unhandled_hints)
@@ -78,7 +78,7 @@ class TestPandasToCsvOptionsDateformats(unittest.TestCase):
                                        'datetimeformattz': 'DD-MM-YYYY HH24:MI:SS',
                                        'datetimeformat': 'DD-MM-YYYY HH24:MI:SS',
                                    })
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         actual = pandas_to_csv_options(records_format, unhandled_hints, processing_instructions)
         self.assertEqual(expected, actual)
         self.assertFalse(unhandled_hints)
@@ -104,7 +104,7 @@ class TestPandasToCsvOptionsDateformats(unittest.TestCase):
                                        'datetimeformattz': 'MM/DD/YY HH24:MI:SS',
                                        'datetimeformat': 'MM/DD/YY HH24:MI:SS',
                                    })
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         actual = pandas_to_csv_options(records_format, unhandled_hints, processing_instructions)
         self.assertEqual(expected, actual)
         self.assertFalse(unhandled_hints)

--- a/tests/unit/records/test_pandas_to_csv_options_vertica.py
+++ b/tests/unit/records/test_pandas_to_csv_options_vertica.py
@@ -19,7 +19,7 @@ class TestPandasToCsvOptionsVertica(unittest.TestCase):
         }
         processing_instructions = ProcessingInstructions()
         records_format = DelimitedRecordsFormat(hints=vertica_format_hints)
-        unhandled_hints = set()
+        unhandled_hints = set(records_format.hints)
         actual = pandas_to_csv_options(records_format, unhandled_hints, processing_instructions)
         self.assertEqual(expected, actual)
         self.assertFalse(unhandled_hints)


### PR DESCRIPTION
It looks like a bunch of tests pretended to validate that all hints passed to the code were handled - but they weren't actually validating that!

This fixes those tests, as well as fixes one bug in the Postgres driver revealed by that.