### PR TITLE
Bug fix: Be more specific on timeout exceptions

### DIFF
--- a/records_mover/db/redshift/unloader.py
+++ b/records_mover/db/redshift/unloader.py
@@ -89,7 +89,7 @@ class RedshiftUnloader(Unloader):
                 logger.info(f"Just unloaded {rows} rows")
                 out.close()
             except sqlalchemy.exc.DatabaseError as e:
-                if 'Operation timed out' in str(e):
+                if 'SSL SYSCALL error: Operation timed out' in str(e):
                     # Large database UNLOADs can take hours, and it's
                     # likely the connection between the client and
                     # server will get disconnected.  In this


### PR DESCRIPTION
It turns out that not having a VPN connection results in a timeout exception very similar (but not exactly the same as) the exception I've been getting after long unloads gets accidentally disconnected.

As a result, we'll need to refine the expectations a bit to avoid effectively hanging for the user when we could be delivering a better error message.