### PR TITLE
Ensure close() is called on result of pandas.read_sql(chunksize=...)

### DIFF
--- a/tests/unit/records/sources/test_table.py
+++ b/tests/unit/records/sources/test_table.py
@@ -35,6 +35,7 @@ class TestTableRecordsSource(unittest.TestCase):
         mock_columns = [mock_column]
         mock_db.dialect.get_columns.return_value = mock_columns
         mock_quoted_table = mock_quote_schema_and_table.return_value
+        mock_chunks = mock_read_sql.return_value
         with self.table_records_source.to_dataframes_source(mock_processing_instructions) as\
                 df_source:
             self.assertEqual(df_source, mock_DataframesRecordsSource.return_value)
@@ -51,6 +52,8 @@ class TestTableRecordsSource(unittest.TestCase):
                 assert_called_with(dfs=ANY,
                                    processing_instructions=mock_processing_instructions,
                                    records_schema=mock_records_schema)
+            mock_chunks.close.assert_not_called()
+        mock_chunks.close.assert_called()
 
     @patch('records_mover.records.sources.table.RecordsUnloadPlan')
     @patch('records_mover.records.sources.table.MoveResult')


### PR DESCRIPTION
While writing new integration tests in #140, I started hitting frozen tests and 'too many open connection' errors from Redshift.  The patch inside this PR fixed it - it appears that we were not closing the SQL connection opened while reading chunked dataframes, which resulted in simultaneous connections piling up and table locks in the integration tests.