### PR TITLE
Tweak collections.abc import to resolve mypy issue

### DIFF
--- a/records_mover/utils/json_schema.py
+++ b/records_mover/utils/json_schema.py
@@ -21,8 +21,6 @@ PythonType = Any
 
 def is_iterable_type(python_type: PythonType) -> bool:
     return get_origin(python_type) in [
-        # mypy reports error: Module has no attribute "abc", which is not true:
-        # https://docs.python.org/3/library/collections.abc.html
         collections.abc.Iterable,
         typing.Iterable,
         typing.List,

--- a/records_mover/utils/json_schema.py
+++ b/records_mover/utils/json_schema.py
@@ -4,7 +4,7 @@ import enum
 import inspect
 import typing
 from typing_inspect import get_origin, is_callable_type, get_args, is_union_type
-import collections
+import collections.abc
 import logging
 from collections import OrderedDict
 from ..mover_types import JsonSchema
@@ -23,7 +23,7 @@ def is_iterable_type(python_type: PythonType) -> bool:
     return get_origin(python_type) in [
         # mypy reports error: Module has no attribute "abc", which is not true:
         # https://docs.python.org/3/library/collections.abc.html
-        collections.abc.Iterable,  # type: ignore
+        collections.abc.Iterable,
         typing.Iterable,
         typing.List,
         list


### PR DESCRIPTION
Recently, type checking started breaking in builds with this error:

```
records_mover/utils/json_schema.py:26: error: unused 'type: ignore' comment
```

My best guess is that it is a difference between python 3.9.1 and python 3.9.2. In any case, it turns out that simply changing the import from `collections` to `collections.abc` resolved the issue that made the `type: ignore` comment relevant in the first place.