### PR TITLE
RM-70 cap sqlalchemy-redshift < 0.8.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,7 @@ mysql_dependencies = [
 
 redshift_dependencies_base = [
     # sqlalchemy-redshift 0.7.7 introduced support for Parquet in UNLOAD
-    'sqlalchemy-redshift>=0.7.7',
+    'sqlalchemy-redshift>=0.7.7,<0.8.13',
 ] + aws_dependencies + db_dependencies
 
 redshift_dependencies_binary = [


### PR DESCRIPTION
sqlalchemy-redshift recently released a new version with this problematic looking code

```python
    def get_table_oid(self, connection, table_name, schema=None, **kw):
        """Fetch the oid for schema.table_name.
        Return null if not found (external table does not have table oid)"""
        schema_clause = (
            "AND schema = '{schema}'".format(schema=schema) if schema else ""
        )

        result = connection.execute("""
                        SELECT table_id
                        FROM
                            SVV_TABLE_INFO
                        WHERE 1
                            {schema_clause}
                            AND "table" = '{table_name}';
                        """.format(
                                schema_clause=schema_clause,
                                table_name=table_name)
                            )

        return result.scalar()
```
