### PR TITLE
RM-80 add slack notifications for fail and deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ quality_gem_version: &quality_gem_version python-37
 
 orbs:
   quality: bluelabs/quality@0.0.2
+  slack: circleci/slack@4.12.1
 
 commands:
   installvenv:
@@ -160,6 +161,12 @@ jobs:
           path: cover.tar.gz
       - store_artifacts:
           path: typecover.tar.gz
+      - slack/notify:
+          event: fail
+          branch_pattern: main
+          channel: engineering-general
+          mentions: '<@bruno.castrokarney>'
+          template: basic_fail_1
 
   integration_test_with_dbs:
     parameters:
@@ -254,6 +261,12 @@ jobs:
           path: test-reports
       - store_artifacts:
           path: test-reports
+      - slack/notify:
+          event: fail
+          branch_pattern: main
+          channel: engineering-general
+          mentions: '<@bruno.castrokarney>'
+          template: basic_fail_1
 
   integration_test:
     parameters:
@@ -318,6 +331,12 @@ jobs:
           path: test-reports
       - store_artifacts:
           path: test-reports
+      - slack/notify:
+          event: fail
+          branch_pattern: main
+          channel: engineering-general
+          mentions: '<@bruno.castrokarney>'
+          template: basic_fail_1
 
   deploy:
     parameters:
@@ -366,6 +385,17 @@ jobs:
           command: |
             . venv/bin/activate
             twine upload -r pypi dist/*
+      - slack/notify:
+          event: fail
+          branch_pattern: main
+          channel: engineering-general
+          mentions: '<@bruno.castrokarney>'
+          template: basic_fail_1
+      - slack/notify:
+          event: pass
+          channel: engineering-general
+          template: success_tagged_deploy_1
+
   cli-extra-test:
     docker:
       - image: cimg/python:3.9
@@ -384,6 +414,12 @@ jobs:
             . venv/bin/activate
             mvrec --help
             mvrec
+      - slack/notify:
+          event: fail
+          branch_pattern: main
+          channel: engineering-general
+          mentions: '<@bruno.castrokarney>'
+          template: basic_fail_1
 
 workflows:
   version: 2
@@ -402,6 +438,7 @@ workflows:
           extras: '[unittest,typecheck]'
           python_version: "3.7"
           pandas_version: "==1.1.5"
+          context: slack-secrets
           filters:
             tags:
               only: /v\d+\.\d+\.\d+(-[\w]+)?/
@@ -410,6 +447,7 @@ workflows:
           extras: '[unittest,typecheck]'
           python_version: "3.8"
           pandas_version: "==1.1.5"
+          context: slack-secrets
           filters:
             tags:
               only: /v\d+\.\d+\.\d+(-[\w]+)?/
@@ -418,6 +456,7 @@ workflows:
           extras: '[unittest,typecheck]'
           python_version: "3.9"
           pandas_version: "==1.1.5"
+          context: slack-secrets
           coverage: true
           filters:
             tags:
@@ -427,6 +466,7 @@ workflows:
           extras: '[unittest,typecheck]'
           python_version: "3.10"
           pandas_version: "==1.5.2"
+          context: slack-secrets
           coverage: true
           filters:
             tags:
@@ -436,6 +476,7 @@ workflows:
           extras: '[unittest,typecheck]'
           python_version: "3.10"
           pandas_version: "==1.5.2"
+          context: slack-secrets
           coverage: true
           filters:
             tags:
@@ -444,6 +485,7 @@ workflows:
           name: vertica-no-s3-itest
           extras: '[vertica,itest]'
           python_version: "3.9"
+          context: slack-secrets
           command: |
             . venv/bin/activate
             export PATH=${PATH}:${PWD}/tests/integration/bin:/opt/vertica/bin
@@ -465,6 +507,7 @@ workflows:
           extras: '[postgres-binary,itest]'
           python_version: "3.9"
           pandas_version: '==1.3.5'
+          context: slack-secrets
           command: |
             . venv/bin/activate
             export PATH=${PATH}:${PWD}/tests/integration/bin:/opt/vertica/bin
@@ -485,6 +528,7 @@ workflows:
           #
           # See https://github.com/bluelabsio/records-mover/pull/152
           pandas_version: "==1.1.5"
+          context: slack-secrets
           command: |
             . venv/bin/activate
             export PATH=${PATH}:${PWD}/tests/integration/bin:/opt/vertica/bin
@@ -500,6 +544,7 @@ workflows:
           name: vertica-s3-itest
           extras: '[vertica,aws,itest]'
           python_version: "3.9"
+          context: slack-secrets
           command: |
             . venv/bin/activate
             export PATH=${PATH}:${PWD}/tests/integration/bin:/opt/vertica/bin
@@ -515,6 +560,7 @@ workflows:
           name: cli-1-itest
           extras: '[cli,gsheets,vertica]'
           python_version: "3.9"
+          context: slack-secrets
           command: |
             . venv/bin/activate
             export PATH=${PATH}:${PWD}/tests/integration/bin:/opt/vertica/bin
@@ -530,6 +576,7 @@ workflows:
           name: cli-2-itest
           extras: '[cli,gsheets,vertica]'
           python_version: "3.9"
+          context: slack-secrets
           command: |
             . venv/bin/activate
             export PATH=${PATH}:${PWD}/tests/integration/bin:/opt/vertica/bin
@@ -545,6 +592,7 @@ workflows:
           name: cli-3-itest
           extras: '[cli,gsheets,vertica]'
           python_version: "3.9"
+          context: slack-secrets
           command: |
             . venv/bin/activate
             export PATH=${PATH}:${PWD}/tests/integration/bin:/opt/vertica/bin
@@ -560,6 +608,7 @@ workflows:
           name: redshift-s3-itest
           extras: '[redshift-binary,itest]'
           python_version: "3.9"
+          context: slack-secrets
           db_name: demo-itest
           filters:
             tags:
@@ -568,6 +617,7 @@ workflows:
           name: redshift-no-s3-itest
           extras: '[redshift-binary,itest]'
           python_version: "3.9"
+          context: slack-secrets
           db_name: demo-itest
           include_s3_scratch_bucket: false
           filters:
@@ -579,6 +629,7 @@ workflows:
           python_version: "3.8"
           pandas_version: "<1"
           numpy_version: "<1.24"
+          context: slack-secrets
           db_name: demo-itest
           filters:
             tags:
@@ -588,6 +639,7 @@ workflows:
           extras: '[redshift-binary,itest]'
           python_version: "3.9"
           pandas_version: ""
+          context: slack-secrets
           db_name: demo-itest
           filters:
             tags:
@@ -597,6 +649,7 @@ workflows:
           extras: '[literally_every_single_database_binary,itest]'
           python_version: "3.9"
           pandas_version: "==1.1.5"
+          context: slack-secrets
           command: |
             . venv/bin/activate
             export PATH=${PATH}:${PWD}/tests/integration/bin:/opt/vertica/bin
@@ -609,6 +662,7 @@ workflows:
           name: bigquery-no-gcs-itest
           extras: '[bigquery,itest]'
           python_version: "3.9"
+          context: slack-secrets
           db_name: bltoolsdevbq-bq_itest
           include_gcs_scratch_bucket: false
           filters:
@@ -618,14 +672,18 @@ workflows:
           name: bigquery-gcs-itest
           extras: '[bigquery,itest]'
           python_version: "3.9"
+          context: slack-secrets
           db_name: bltoolsdevbq-bq_itest
           filters:
             tags:
               only: /v\d+\.\d+\.\d+(-[\w]+)?/
       - cli-extra-test:
           name: cli-extra-test
+          context: slack-secrets
       - deploy:
-          context: PyPI
+          context: 
+            - PyPI
+            - slack-secrets
           requires:
             - test-3.7
             - test-3.8


### PR DESCRIPTION
Adds Slack notifications for test failures on main branch.

This will /mainly/ trigger on nightly builds, since we shouldn't be committing broken code to main generally.