### PR TITLE
adjust deploy build step to work with pyproject.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ quality:
 	       "apiology/quality:$${quality_gem_version}" ${QUALITY_TOOL}
 
 package:
-	python3 setup.py sdist bdist_wheel
+	python3 -m build
+	twine check dist/*
 
 docker:
 	docker build -f tests/integration/Dockerfile --progress=plain -t records-mover .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 setuptools>34.3.0
 wheel
 twine
+build
 flake8
 markupsafe
 google-cloud-storage


### PR DESCRIPTION
When we moved from setup.py to pyproject.yaml, the `make package` command broke. this is the first time trying to push a release after this change - these are the necessary adjustments.