### PR TITLE
RM-130 reapply previous fix to set mypy to a valid version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ alldb = [
 ]
 
 typecheck = [
-    "mypy@git+https://github.com/python/mypy#88ae1e4c1541e5b03d695cf63d1265b972e427d9",
+    "mypy>=1.7.1",
     # update to build from mypy without version qualifier soon
     "lxml", # needed by mypy HTML coverage reporting
     "sqlalchemy-stubs>=0.3",


### PR DESCRIPTION
A long time ago, mypy was set to this specific git commit version.
Several months ago, i updated it to use 1.7.1
But when moving to pyproject.toml it regressed back to the git commit version

Need to put it back to a release version